### PR TITLE
Inject epgsql application version into epgsql.app when compiled with rebar

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,0 +1,1 @@
+{post_hooks, [{compile, "sed -e s/VERSION/1.4/g src/epgsql.app.src > ebin/epgsql.app"}]}.


### PR DESCRIPTION
This is to imitate Makefile's behaviour. Otherwise's epgsql version remains `VERSION` which is not a terribly good idea, especially when you're dealing with releases.
